### PR TITLE
docs: fix autosummary table links regressed to object anchors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,3 +56,4 @@ def _strip_autosummary_anchors(app, doctree, docname):
 
 def setup(app):
     app.connect("doctree-resolved", _strip_autosummary_anchors)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,3 +34,25 @@ try:
     version = release = _version("jlgametheory")
 except PackageNotFoundError:
     version = release = ""
+
+
+def _strip_autosummary_anchors(app, doctree, docname):
+    """Point autosummary table links at the page, not the object's anchor.
+
+    Sphinx links each autosummary entry to the object's anchor
+    (e.g. ``_autosummary/jlgametheory.lrsnash.html#jlgametheory.lrsnash``);
+    drop the ``#fragment`` so the link targets the page itself.
+    """
+    from docutils import nodes
+
+    for table in doctree.findall(nodes.table):
+        if "autosummary" not in table.get("classes", []):
+            continue
+        for ref in table.findall(nodes.reference):
+            uri = ref.get("refuri")
+            if uri and "#" in uri:
+                ref["refuri"] = uri.split("#", 1)[0]
+
+
+def setup(app):
+    app.connect("doctree-resolved", _strip_autosummary_anchors)


### PR DESCRIPTION
## Regression fix

On the index page, the autosummary table links regressed from pointing at the page (`_autosummary/jlgametheory.lrsnash.html`) to pointing at the object anchor (`_autosummary/jlgametheory.lrsnash.html#jlgametheory.lrsnash`).

### Cause
Sphinx's `autosummary` extension generates each table entry as a link to the documented object's anchor. The site had long dropped that `#fragment` via a small client-side snippet in `autosummary_fixes.js`. PR #20 (issue #3) deleted that file, judging the fragment redundant — but the script was actively rewriting the link URLs, so removing it let Sphinx's default anchored links stand. The static build looked fine because the rewrite only happened at page load.

### Fix
Restore the original behaviour **server-side** via a `doctree-resolved` hook that strips the `#fragment` from autosummary *table* references only. Compared to the old JS this:
- is reflected directly in the generated HTML (verifiable in the static build),
- needs no client-side JavaScript,
- leaves every other link (prose links, the function's own anchor, viewcode `[source]`) untouched.

### Verification
Local Sphinx 9.1 build, warning-free:
- index table links → `_autosummary/jlgametheory.lrsnash.html` and `…hc_solve.html` (no fragment) ✓
- signature still renders `jlgametheory.lrsnash` (from #19) ✓
- function anchor `id` and viewcode `[source]` link preserved ✓
- external prose links unchanged ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
