### PR TITLE
docs: use a dynamic copyright year range (mimic QuantEcon.py)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,9 +1,11 @@
 import os
 import sys
+from datetime import datetime
 sys.path.insert(0, os.path.abspath('..'))
 
 project = "jlgametheory"
-copyright = "2025, QuantEcon"
+year = datetime.now().year
+copyright = f"2025-{year}, QuantEcon"
 author = "QuantEcon"
 extensions = [
     "sphinx.ext.autodoc",


### PR DESCRIPTION
Mirror QuantEcon.py's `conf.py` for the copyright string, which builds a dynamic year range:

```python
year = datetime.now().year
copyright = f'2014-{year}, QuantEcon Developer Team'
```

Here the start year is `2025` (this project's first year, per `LICENSE`) and the holder stays `QuantEcon` to match the repo's `LICENSE`:

```python
year = datetime.now().year
copyright = f"2025-{year}, QuantEcon"
```

The footer now reads `© Copyright 2025-2026, QuantEcon.` and tracks the current year automatically — no annual edit needed.

## Verification
Local Sphinx 9.1 build, warning-free; rendered footer confirmed as `© Copyright 2025-2026, QuantEcon.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
